### PR TITLE
Using old 1.1 in-game event logger format

### DIFF
--- a/InfinityScript/Scripts/InternalScript.cs
+++ b/InfinityScript/Scripts/InternalScript.cs
@@ -62,23 +62,23 @@ namespace InfinityScript.Scripts
         }
 
         private void LoggerPlayerConnected(Entity player) =>
-            Write("OnPlayerConnected;{0};{1};{2}", player.HWID, player.EntRef, player.Name);
+            Write("J;{0};{1};{2}", player.GUID, player.EntRef, player.Name);
 
         public override void OnPlayerDisconnect(Entity player) =>
-            Write("OnPlayerDisconnect;{0};{1};{2}", player.HWID, player.EntRef, player.Name);
+            Write("Q;{0};{1};{2}", player.GUID, player.EntRef, player.Name);
 
         public override void OnPlayerDamage(Entity player, Entity inflictor, Entity attacker, int damage, int dFlags, string mod, string weapon, Vector3 point, Vector3 dir, string hitLoc) =>
-            Write("OnPlayerDamage;{0};{1};{2};{3};{4};{5}", GetDamageDetails(player), GetDamageDetails(attacker), weapon, damage, mod, hitLoc);
+            Write("D;{0};{1};{2};{3};{4};{5}", GetDamageDetails(player), GetDamageDetails(attacker), weapon, damage, mod, hitLoc);
 
         public override void OnPlayerKilled(Entity player, Entity inflictor, Entity attacker, int damage, string mod, string weapon, Vector3 dir, string hitLoc) 
-            => Write("OnPlayerKilled;{0};{1};{2};{3};{4};{5}", GetDamageDetails(player), GetDamageDetails(attacker), weapon, damage, mod, hitLoc);
+            => Write("K;{0};{1};{2};{3};{4};{5}", GetDamageDetails(player), GetDamageDetails(attacker), weapon, damage, mod, hitLoc);
 
         public override void OnSay(Entity player, string name, string message)
         {
             if (message.StartsWith("/"))
                 message = message.Substring(1);
 
-            Write("OnSay;{0};{1};{2};{3}", player.HWID, player.EntRef, name, message);
+            Write("say;{0};{1};{2};{3}", player.GUID, player.EntRef, name, message);
         }
 
         public override void OnExitLevel()
@@ -90,7 +90,7 @@ namespace InfinityScript.Scripts
         {
             if (player == null || !player.IsPlayer)
                 return ";-1;world;world";
-            return string.Format("{0};{1};{2};{3}", player.HWID, player.EntRef, player.SessionTeam, player.Name);
+            return string.Format("{0};{1};{2};{3}", player.GUID, player.EntRef, player.SessionTeam, player.Name);
         }
         #endregion
 


### PR DESCRIPTION
Using 1.1 formats will allow parsers for iw4m to read the mp_log text file correctly and enable admins to execute commands through the chat.
Thanks a lot, S3VDITO!
Best regards,
Diavolo